### PR TITLE
Fix OrganizationURL-missing error

### DIFF
--- a/app/src/AppBundle/Utils/SSPGetter.php
+++ b/app/src/AppBundle/Utils/SSPGetter.php
@@ -178,6 +178,9 @@ class SSPGetter
                         $result[$idp->getEntityId($this->samlidp_hostname)]['OrganizationURL'][$orgElem->getLang()] = $orgElem->getValue();
                     }
                 }
+                if (!$result[$idp->getEntityId($this->samlidp_hostname)]['OrganizationURL'][$orgElem->getLang()]){
+                    $result[$idp->getEntityId($this->samlidp_hostname)]['OrganizationURL'][$orgElem->getLang()] = $idp->getInstituteUrl();
+                }
 
                 # authproc dynamic parts
                 $result[$idp->getEntityId($this->samlidp_hostname)]['authproc'][16] = array(


### PR DESCRIPTION
This PR fixes the error page that shows up on the metadata page. On the terminal, it shows the error `If OrganizationName is set, OrganizationURL must also be set.`