### PR TITLE
Fix Unhandled exception when loging into SP

### DIFF
--- a/app/src/AppBundle/Utils/SSPGetter.php
+++ b/app/src/AppBundle/Utils/SSPGetter.php
@@ -208,6 +208,9 @@ class SSPGetter
             );
         }
         # for production use here could come some error handling
+        if (!$idpUser) {
+            return;
+        }
         return $idpUser->getSalt();
     }
 


### PR DESCRIPTION
**Overview**:
This fixes the error page seen by a user when trying to login to a Service Provider using the IdP. The error doesn't provide enough info to the user as to what the problem could be. With this fix the user gets a meaningful error message.

**Steps to reproduce this bug:**

1. Go to https://attributes.ngren.eduid.africa/

2. Select an IdP

3. Enter a wrong **username**

4. Click Login

 
**Issue:**
![image](https://user-images.githubusercontent.com/19332232/81938483-e2e99200-95ec-11ea-8f28-75bf2b92cb14.png)

 
**Fixed:**
![image](https://user-images.githubusercontent.com/19332232/81938536-f4329e80-95ec-11ea-9ad0-924f0c6c6543.png)
